### PR TITLE
feat(jest-config): set jest/padding-around-all rule to warn

### DIFF
--- a/src/configs/jest.mts
+++ b/src/configs/jest.mts
@@ -14,6 +14,7 @@ const jestConfig = config({
   rules: {
     ...jestPlugin.configs.recommended.rules,
     ...jestPlugin.configs.style.rules,
+    'jest/padding-around-all': 'warn',
   },
 });
 


### PR DESCRIPTION
This PR enables the jest eslint rules that forces space around tests, describe, beforeAll... 
https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/padding-around-all.md
closes #51 